### PR TITLE
fixed a bug that caused the get command to display a go error

### DIFF
--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func kvget(c *cli.Context) {
 		return
 	}
 
-	fmt.Printf("%s\n", pair.Key, string(pair.Value))
+	fmt.Printf("%s", string(pair.Value))
 }
 
 func kvset(c *cli.Context) {


### PR DESCRIPTION
If the value for key /key1 is set to "test" as an example, the output of:
`consul-kv get /web/key1` is:

```
web/key1
%!(EXTRA string=test)
```

This PR fixes this by only displaying the value of the pair without any extra formatting.
